### PR TITLE
Add phpstan files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,6 +12,8 @@ package.json
 phpdoc.xml
 phpunit.xml.dist
 phpcs.ruleset.xml
+phpstan.neon
+phpstan-baseline.neon
 composer.lock
 README.md
 readme.txt.bak


### PR DESCRIPTION
## Summary
- Add phpstan.neon and phpstan-baseline.neon to .distignore to exclude from WordPress.org deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)