### PR TITLE
Add structured data testing tool links to settings page

### DIFF
--- a/templates/setting.php
+++ b/templates/setting.php
@@ -87,12 +87,12 @@ $places = \Tarosky\OpenHour\Places::instance();
 		</table>
 
 		<p class="description">
-			<?php esc_html_e( 'This plugin outputs structured data (JSON-LD) for business locations. You can validate your markup with Google\'s testing tools:', 'taro-open-hour' ); ?>
-			<a href="https://search.google.com/test/rich-results" target="_blank" rel="noopener noreferrer">
+			<?php esc_html_e( 'This plugin outputs structured data (JSON-LD) for business locations. You can validate your markup with the following tools:', 'taro-open-hour' ); ?>
+			<a href="<?php echo esc_url( 'https://search.google.com/test/rich-results' ); ?>" target="_blank" rel="noopener noreferrer">
 				<?php esc_html_e( 'Rich Results Test', 'taro-open-hour' ); ?>
 			</a>
 			|
-			<a href="https://validator.schema.org/" target="_blank" rel="noopener noreferrer">
+			<a href="<?php echo esc_url( 'https://validator.schema.org/' ); ?>" target="_blank" rel="noopener noreferrer">
 				<?php esc_html_e( 'Schema Markup Validator', 'taro-open-hour' ); ?>
 			</a>
 		</p>


### PR DESCRIPTION
## Summary
Closes #12

設定画面の Business Places セクションに、構造化データ（JSON-LD）の検証ツールへのリンクを追加:

- [Rich Results Test](https://search.google.com/test/rich-results) — Google の公式テストツール
- [Schema Markup Validator](https://validator.schema.org/) — Schema.org のバリデーター

元イシューの URL（Structured Data Testing Tool）は廃止済みのため、後継ツールのリンクに置き換えています。

## Test plan
- [x] `composer lint` パス
- [x] `composer phpstan` パス
- [x] 設定画面にリンクが正しく表示されることを確認（スクリーンショット確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)